### PR TITLE
Fixes: pydantic validation, MailTMInvalidResponse args, SSLCertVerificationError

### DIFF
--- a/mailtmapi/mailtm.py
+++ b/mailtmapi/mailtm.py
@@ -14,11 +14,12 @@ logger = logging.getLogger('mailtm')
 
 class MailTM:
     API_URL = "https://api.mail.tm"
+    SSL = False
 
     def __init__(self, session: ClientSession = None):
         self.session = session or ClientSession()
 
-    async def get_account_token(self, address, password) -> Token:
+    async def get_account_token(self, address: str, password: str) -> Token:
         """
         https://docs.mail.tm/#authentication
         """
@@ -29,36 +30,37 @@ class MailTM:
         response = await self.session.post(f"{self.API_URL}/token", data=json.dumps({
             "address": address,
             "password": password
-        }), headers=headers)
+        }), headers=headers, ssl=self.SSL)
         logger.debug(f'Response for {self.API_URL}/token: {response}')
         if await validate_response(response):
             return Token(**(await response.json()))
         logger.debug(f'Error response for {self.API_URL}/token: {response}')
-        raise MailTMInvalidResponse
+        raise MailTMInvalidResponse(f"Error response for {self.API_URL}/token", await response.json())
 
     async def get_domains(self) -> Domains:
         """
         https://docs.mail.tm/#get-domains
         """
-        response = await self.session.get(f"{self.API_URL}/domains")
+        response = await self.session.get(f"{self.API_URL}/domains", ssl=self.SSL)
         logger.debug(f'Response for {self.API_URL}/domains: {response}')
         if await validate_response(response):
             return Domains(**(await response.json()))
         logger.debug(f'Error response for {self.API_URL}/domains: {response}')
-        raise MailTMInvalidResponse
+        raise MailTMInvalidResponse(f"Error response for {self.API_URL}/domains", await response.json())
 
-    async def get_domain(self, domain_id) -> Domain:
+    async def get_domain(self, domain_id: str) -> Domain:
         """
         https://docs.mail.tm/#get-domainsid
         """
-        response = await self.session.get(f"{self.API_URL}/domains/{domain_id}")
+        response = await self.session.get(f"{self.API_URL}/domains/{domain_id}", ssl=self.SSL)
         logger.debug(f'Response for {self.API_URL}/domains/{domain_id}: {response}')
         if await validate_response(response):
             return Domain(**(await response.json()))
         logger.debug(f'Error response for {self.API_URL}/domains/{domain_id}: {response}')
-        raise MailTMInvalidResponse
+        raise MailTMInvalidResponse(f"Error response for {self.API_URL}/domains/{domain_id}",
+                                    await response.json())
 
-    async def get_account(self, address=None, password=None) -> Account:
+    async def get_account(self, address: str = None, password: str = None) -> Account:
         """
         https://docs.mail.tm/#post-accounts
         """
@@ -72,7 +74,7 @@ class MailTM:
             "password": password
         }
         logger.debug(f'Create account with payload: {payload}')
-        response = await self.session.post(f"{self.API_URL}/accounts", json=payload)
+        response = await self.session.post(f"{self.API_URL}/accounts", json=payload, ssl=self.SSL)
         logger.debug(f'Response for {self.API_URL}/accounts: {response}')
         if await validate_response(response):
             response = await response.json()
@@ -80,99 +82,120 @@ class MailTM:
             response['token'] = token
             return Account(**response)
         logger.debug(f'Error response for {self.API_URL}/accounts: {response}')
-        raise MailTMInvalidResponse
+        raise MailTMInvalidResponse(f"Error response for {self.API_URL}/accounts", await response.json())
 
-    async def get_account_by_id(self, account_id, token) -> Account:
+    async def get_account_by_id(self, account_id: str, token: str) -> Account:
         """
         https://docs.mail.tm/#get-accountsid
         """
         response = await self.session.get(f"{self.API_URL}/accounts/{account_id}",
-                                          headers={"Authorization": f"Bearer {token}"})
+                                          headers={"Authorization": f"Bearer {token}"},
+                                          ssl=self.SSL)
         logger.debug(f'Response for {self.API_URL}/accounts/{account_id}: {response}')
         if await validate_response(response):
-            return Account(**(await response.json()))
+            data = await response.json()
+            if 'token' not in data:
+                data['token'] = Token(**({'id': account_id, 'token': token}))
+            return Account(**data)
         logger.debug(f'Error response for {self.API_URL}/accounts/{account_id}: {response}')
-        raise MailTMInvalidResponse
+        raise MailTMInvalidResponse(f"Error response for {self.API_URL}/accounts/{account_id}",
+                                    await response.json())
 
-    async def delete_account_by_id(self, account_id, token) -> bool:
+    async def delete_account_by_id(self, account_id: str, token: str) -> bool:
         """
         https://docs.mail.tm/#delete-accountsid
         """
         response = await self.session.delete(f"{self.API_URL}/accounts/{account_id}",
-                                             headers={'Authorization': f'Bearer {token}'})
+                                             headers={'Authorization': f'Bearer {token}'},
+                                             ssl=self.SSL)
         logger.debug(f'Response for {self.API_URL}/accounts/{account_id}: {response}')
         if await validate_response(response):
             return response.status == 204
         logger.debug(f'Error response for {self.API_URL}/accounts/{account_id}: {response}')
-        raise MailTMInvalidResponse
+        raise MailTMInvalidResponse(f"Error response for {self.API_URL}/accounts/{account_id}",
+                                    await response.json())
 
-    async def get_me(self, token) -> Account:
+    async def get_me(self, token: str) -> Account:
         """
         https://docs.mail.tm/#get-me
         """
-        response = await self.session.get(f"{self.API_URL}/me", headers={'Authorization': f'Bearer {token}'})
+        response = await self.session.get(f"{self.API_URL}/me",
+                                          headers={'Authorization': f'Bearer {token}'},
+                                          ssl=self.SSL)
         logger.debug(f'Response for {self.API_URL}/me: {response}')
         if await validate_response(response):
-            return Account(**(await response.json()))
+            data = await response.json()
+            if 'token' not in data:
+                data['token'] = Token(**({'id': data['id'], 'token': token}))
+            return Account(**data)
         logger.debug(f'Error response for {self.API_URL}/me: {response}')
-        raise MailTMInvalidResponse
+        raise MailTMInvalidResponse(f"Error response for {self.API_URL}/me", await response.json())
 
-    async def get_messages(self, token, page=1) -> Messages:
+    async def get_messages(self, token: str, page: int = 1) -> Messages:
         """
         https://docs.mail.tm/#get-messages
         """
         response = await self.session.get(f"{self.API_URL}/messages?page={page}",
-                                          headers={'Authorization': f'Bearer {token}'})
+                                          headers={'Authorization': f'Bearer {token}'},
+                                          ssl=self.SSL)
         logger.debug(f'Response for {self.API_URL}/messages: {response}')
         if await validate_response(response):
             return Messages(**(await response.json()))
         logger.debug(f'Error response for {self.API_URL}/messages: {response}')
-        raise MailTMInvalidResponse
+        raise MailTMInvalidResponse(f"Error response for {self.API_URL}/messages", await response.json())
 
-    async def get_message_by_id(self, message_id, token) -> OneMessage:
+    async def get_message_by_id(self, message_id: str, token: str) -> OneMessage:
         """
         https://docs.mail.tm/#get-messagesid
         """
         response = await self.session.get(f"{self.API_URL}/messages/{message_id}",
-                                          headers={'Authorization': f'Bearer {token}'})
+                                          headers={'Authorization': f'Bearer {token}'},
+                                          ssl=self.SSL)
         logger.debug(f'Response for {self.API_URL}/messages/{message_id}: {response}')
         if await validate_response(response):
             return OneMessage(**(await response.json()))
         logger.debug(f'Error response for {self.API_URL}/messages/{message_id}: {response}')
-        raise MailTMInvalidResponse
+        raise MailTMInvalidResponse(f"Error response for {self.API_URL}/messages/{message_id}",
+                                    await response.json())
 
-    async def delete_message_by_id(self, message_id, token) -> bool:
+    async def delete_message_by_id(self, message_id: str, token: str) -> bool:
         """
         https://docs.mail.tm/#delete-messagesid
         """
         response = await self.session.delete(f"{self.API_URL}/messages/{message_id}",
-                                             headers={'Authorization': f'Bearer {token}'})
+                                             headers={'Authorization': f'Bearer {token}'},
+                                             ssl=self.SSL)
         logger.debug(f'Response for {self.API_URL}/messages/{message_id}: {response}')
         if await validate_response(response):
             return response.status == 204
         logger.debug(f'Error response for {self.API_URL}/messages/{message_id}: {response}')
-        raise MailTMInvalidResponse
+        raise MailTMInvalidResponse(f"Error response for {self.API_URL}/messages/{message_id}",
+                                    await response.json())
 
-    async def set_read_message_by_id(self, message_id, token) -> bool:
+    async def set_read_message_by_id(self, message_id: str, token: str) -> bool:
         """
         https://docs.mail.tm/#patch-messagesid
         """
         response = await self.session.put(f"{self.API_URL}/messages/{message_id}/read",
-                                          headers={'Authorization': f'Bearer {token}'})
+                                          headers={'Authorization': f'Bearer {token}'},
+                                          ssl=self.SSL)
         logger.debug(f'Response for {self.API_URL}/messages/{message_id}/read: {response}')
         if await validate_response(response):
             return (await response.json())['seen'] == "read"
         logger.debug(f'Error response for {self.API_URL}/messages/{message_id}/read: {response}')
-        raise MailTMInvalidResponse
+        raise MailTMInvalidResponse(f"Error response for {self.API_URL}/messages/{message_id}/read",
+                                    await response.json())
 
-    async def get_message_source_by_id(self, message_id, token) -> MessageSource:
+    async def get_message_source_by_id(self, message_id: str, token: str) -> MessageSource:
         """
         https://docs.mail.tm/#get-messagesidsource
         """
         response = await self.session.get(f"{self.API_URL}/messages/{message_id}/source",
-                                          headers={'Authorization': f'Bearer {token}'})
+                                          headers={'Authorization': f'Bearer {token}'},
+                                          ssl=self.SSL)
         logger.debug(f'Response for {self.API_URL}/messages/{message_id}/source: {response}')
         if await validate_response(response):
             return MessageSource(**(await response.json()))
         logger.debug(f'Error response for {self.API_URL}/messages/{message_id}/source: {response}')
-        raise MailTMInvalidResponse
+        raise MailTMInvalidResponse(f"Error response for {self.API_URL}/messages/{message_id}/source",
+                                    await response.json())


### PR DESCRIPTION
Hi, I used your API and encountered several issues. The problems disappeared after I overrode several methods in my code. Now that I’ve had some time, I’ve made changes in your code to ensure everything works as expected. Here’s a list of fixes:

- **Issue with Pydantic validation (token missing in response) in get_account, get_account_by_id, get_me (methods that returns Account model)**:
The problem is that the **Account** model (schema) has a required **token** attribute, but the API response does not include this token. This caused a Pydantic validation error when attempting to return an Account. While it would be possible to define the attribute in the Account class like this: ```token: Token = None```, but this token is essential because it is needed for every request associated with a specific account. 
```
Response from your API
{
  "@context": "string",
  "@id": "string",
  "@type": "string",
  "id": "string",
  "address": "user@example.com",
  "quota": 0,
  "used": 0,
  "isDisabled": true,
  "isDeleted": true,
  "createdAt": "2022-04-01T00:00:00.000Z",
  "updatedAt": "2022-04-01T00:00:00.000Z"
}
```
So we just add the token to the response:
```
if await validate_response(response):
    data = await response.json()
    if 'token' not in data:
        data['token'] = Token(**({'id': account_id, 'token': token}))
    return Account(**data)
```
- **MailTMInvalidResponse arguments:**
The problem was that if our request returned an error, we wouldn’t know the exact cause.
Previously: 
```raise MailTMInvalidResponse```
Now: 
```raise MailTMInvalidResponse(f"Error response for {self.API_URL}/accounts/{account_id}", await response.json()).```
And output will be:
```[ERROR] [MainThread] - root - ('Error response for https://api.mail.tm/messages/1', {'@id': '/errors/404', '@type': 'hydra:Error', 'title': 'An error occurred', 'detail': 'Not Found', 'status': 404, 'type': '/errors/404', 'hydra:title': 'An error occurred', 'hydra:description': 'Not Found'})```
- **SSLCertVerificationError:**
After your SSL certificate expired and was updated, an SSL verification error occurred. To prevent issues when using the API, I decided to disable SSL verification (this can be re-enabled through the SSL class attribute if needed):
```
class MailTM:
    API_URL = "https://api.mail.tm"
    SSL = False
    
    ...
    response = await self.session.post(f"{self.API_URL}/accounts", json=payload, ssl=self.SSL)
```

I’ve tested the key methods, and everything works correctly:
```
[INFO] [MainThread] - root - Created: EmailAccount(id='673fb1b03ee2a9b7f40c8239' address='rd0o8bhe@goeschman.com' quota=40000000 used=0 isDisabled=False isDeleted=False createdAt='2024-11-21T22:18:24+00:00' updatedAt='2024-11-21T22:18:24+00:00' token=Token(id='673fb1b03ee2a9b7f40c8239', token='<JWT_TOKEN>'))
[INFO] [MainThread] - root - test get account by id=(id='673fb1b03ee2a9b7f40c8239' address='rd0o8bhe@goeschman.com' quota=40000000 used=0 isDisabled=False isDeleted=False createdAt='2024-11-21T22:18:24+00:00' updatedAt='2024-11-21T22:18:24+00:00' token=Token(id='673fb1b03ee2a9b7f40c8239', token='<JWT_TOKEN>'))
[INFO] [MainThread] - root - test get me=(id='673fb1b03ee2a9b7f40c8239' address='rd0o8bhe@goeschman.com' quota=40000000 used=0 isDisabled=False isDeleted=False createdAt='2024-11-21T22:18:24+00:00' updatedAt='2024-11-21T22:18:24+00:00' token=Token(id='673fb1b03ee2a9b7f40c8239', token='<JWT_TOKEN>'))
[INFO] [MainThread] - root - test get messages=(hydra_member=[] hydra_totalItems=0 hydra_view=None)
[INFO] [MainThread] - root - Successfully deleted email account at MailTM: id='673fb1b03ee2a9b7f40c8239' address='rd0o8bhe@goeschman.com' quota=40000000 used=0 isDisabled=False isDeleted=False createdAt='2024-11-21T22:18:24+00:00' updatedAt='2024-11-21T22:18:24+00:00' token=Token(id='673fb1b03ee2a9b7f40c8239', token='<JWT_TOKEN>')).
```
